### PR TITLE
Release: slate-core-data v1.1.6

### DIFF
--- a/src/model/person/GlobalRecipient.js
+++ b/src/model/person/GlobalRecipient.js
@@ -1,0 +1,78 @@
+Ext.define('Slate.model.person.GlobalRecipient', {
+    extend: 'Ext.data.Model',
+    requires: [
+        'Slate.proxy.people.GlobalRecipients',
+        'Emergence.ext.proxy.Records',
+        'Ext.data.identifier.Negative',
+        'Ext.data.validator.Presence',
+        'Ext.data.validator.Bound'
+    ],
+
+
+    // model config
+    idProperty: 'ID',
+    identifier: 'negative',
+
+    fields: [
+
+        // ActiveRecord fields
+        {
+            name: 'ID',
+            type: 'int',
+            allowNull: true
+        },
+        {
+            name: 'Class',
+            type: 'string',
+            defaultValue: 'Emergence\\CRM\\GlobalRecipient'
+        },
+        {
+            name: 'Created',
+            type: 'date',
+            dateFormat: 'timestamp',
+            allowNull: true,
+            persist: false
+        },
+        {
+            name: 'CreatorID',
+            type: 'int',
+            allowNull: true,
+            persist: false
+        },
+
+        // GlobalRecipient fields
+        {
+            name: 'PersonID',
+            type: 'int'
+        },
+        {
+            name: 'Title',
+            type: 'string'
+        },
+
+        // dynamic fields
+        {
+            name: 'Person',
+            persist: false,
+            sortType: function(v) {
+                return v ? v.LastName+v.FirstName : '_';
+            }
+        }
+    ],
+
+    proxy: 'slate-globalrecipients',
+
+    validators: [
+        {
+            field: 'Title',
+            type: 'presence',
+            message: 'Title is required'
+        },
+        {
+            field: 'PersonID',
+            type: 'bound',
+            min: 1,
+            message: 'PersonID is required'
+        }
+    ]
+});

--- a/src/proxy/people/GlobalRecipients.js
+++ b/src/proxy/people/GlobalRecipients.js
@@ -1,0 +1,10 @@
+Ext.define('Slate.proxy.people.GlobalRecipients', {
+    extend: 'Slate.proxy.Records',
+    alias: 'proxy.slate-globalrecipients',
+
+
+    config: {
+        url: '/global-recipients',
+        include: ['Person']
+    }
+});

--- a/src/store/people/GlobalRecipients.js
+++ b/src/store/people/GlobalRecipients.js
@@ -1,0 +1,9 @@
+Ext.define('Slate.store.people.GlobalRecipients', {
+    extend: 'Ext.data.Store',
+
+
+    model: 'Slate.model.person.GlobalRecipient',
+    config: {
+        pageSize: 0
+    }
+});


### PR DESCRIPTION
- feat: add model/proxy/store for global recipients